### PR TITLE
#10: Improving Code Maintainability by Using the Diamond Operator in Generic Type Initialization

### DIFF
--- a/robocode.battle/src/main/java/net/sf/robocode/battle/Battle.java
+++ b/robocode.battle/src/main/java/net/sf/robocode/battle/Battle.java
@@ -431,7 +431,7 @@ public final class Battle extends BaseBattle {
 				}
 			}
 			if (isAborted() || isLastRound()) {
-				List<RobotPeer> orderedRobots = new ArrayList<RobotPeer>(robots);
+				List<RobotPeer> orderedRobots = new ArrayList<>(robots);
 				Collections.sort(orderedRobots);
 				Collections.reverse(orderedRobots);
 

--- a/robocode.battle/src/main/java/net/sf/robocode/battle/Battle.java
+++ b/robocode.battle/src/main/java/net/sf/robocode/battle/Battle.java
@@ -755,18 +755,19 @@ public final class Battle extends BaseBattle {
 			int len = coords.length;
 
 			if (len >= 1 && coords[0].trim().length() > 0) {
+				String replacePattern = "[^0-9.]";
 				try {
-					x = Double.parseDouble(coords[0].replaceAll("[^0-9.]", ""));
+					x = Double.parseDouble(coords[0].replaceAll(replacePattern, ""));
 				} catch (NumberFormatException ignore) {// Could be the '?', which is fine
 				}
 				if (len >= 2 && coords[1].trim().length() > 0) {
 					try {
-						y = Double.parseDouble(coords[1].replaceAll("[^0-9.]", ""));
+						y = Double.parseDouble(coords[1].replaceAll(replacePattern, ""));
 					} catch (NumberFormatException ignore) {// Could be the '?', which is fine
 					}
 					if (len >= 3 && coords[2].trim().length() > 0) {
 						try {
-							heading = Math.toRadians(Double.parseDouble(coords[2].replaceAll("[^0-9.]", "")));
+							heading = Math.toRadians(Double.parseDouble(coords[2].replaceAll(replacePattern, "")));
 						} catch (NumberFormatException ignore) {// Could be the '?', which is fine
 						}
 					}

--- a/robocode.battle/src/main/java/net/sf/robocode/battle/Battle.java
+++ b/robocode.battle/src/main/java/net/sf/robocode/battle/Battle.java
@@ -395,12 +395,10 @@ public final class Battle extends BaseBattle {
 	@Override
 	protected void shutdownTurn() {
 		if (endTimer == 0) {
-      
 			handleEndOfBattle();
-    }
-		
+                }
 		if (endTimer > 4 * TURNS_DISPLAYED_AFTER_ENDING) {
-		haltAllRobots();
+			haltAllRobots();
 		}
 
 		super.shutdownTurn();

--- a/robocode.battle/src/main/java/net/sf/robocode/battle/Battle.java
+++ b/robocode.battle/src/main/java/net/sf/robocode/battle/Battle.java
@@ -397,6 +397,7 @@ public final class Battle extends BaseBattle {
 		if (endTimer == 0) {
 			handleEndOfBattle();
                 }
+		
 		if (endTimer > 4 * TURNS_DISPLAYED_AFTER_ENDING) {
 			haltAllRobots();
 		}

--- a/robocode.battle/src/main/java/net/sf/robocode/battle/Battle.java
+++ b/robocode.battle/src/main/java/net/sf/robocode/battle/Battle.java
@@ -397,7 +397,6 @@ public final class Battle extends BaseBattle {
 		if (endTimer == 0) {
 			handleEndOfBattle();
                 }
-		
 		if (endTimer > 4 * TURNS_DISPLAYED_AFTER_ENDING) {
 			haltAllRobots();
 		}

--- a/robocode.battle/src/main/java/net/sf/robocode/battle/Battle.java
+++ b/robocode.battle/src/main/java/net/sf/robocode/battle/Battle.java
@@ -396,7 +396,8 @@ public final class Battle extends BaseBattle {
 	protected void shutdownTurn() {
 		if (endTimer == 0) {
 			handleEndOfBattle();
-                }
+		}
+
 		if (endTimer > 4 * TURNS_DISPLAYED_AFTER_ENDING) {
 			haltAllRobots();
 		}

--- a/robocode.battle/src/main/java/net/sf/robocode/battle/Battle.java
+++ b/robocode.battle/src/main/java/net/sf/robocode/battle/Battle.java
@@ -437,7 +437,7 @@ public final class Battle extends BaseBattle {
 	}
 
 	private void processBattleResults() {
-		List<RobotPeer> orderedRobots = new ArrayList<RobotPeer>(robots);
+		List<RobotPeer> orderedRobots = new ArrayList<>(robots);
 		Collections.sort(orderedRobots);
 		Collections.reverse(orderedRobots);
 


### PR DESCRIPTION
#10 
---
In Java, angular brackets (< and >) are used to define type arguments for generic types, like declaring a list with List<String>. Before Java 7, these type arguments had to be specified explicitly every time generics were used, resulting in redundant code.

Java 7 introduced the diamond operator (<>) to make the code more concise. It allows you to skip the type argument when the compiler can infer it automatically, simplifying the code and reducing verbosity.

However, if the project's Java version (sonar.java.source) is set below 7, this feature is disabled, as the diamond operator is not supported in earlier versions.